### PR TITLE
Explicitly specify All Rights Reserved in License

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
-The code and assets here are ARR, as per the forked (with permission) project.
+The code and assets are All Rights Reserved, as required by the [upstream project](https://github.com/simibubi/Above-and-Beyond) that permitted this fork.
 
-Translations are LGPL v3.
+Translations are licensed under LGPL v3.


### PR DESCRIPTION
The original wording in the license included the unclear license-identifier "ARR". Searching for "ARR license" turned up the [Artist's Resale Right](https://www.gov.uk/guidance/artists-resale-right) license for me, which is very much different from All Rights Reserved.

This PR clarifies the wording and links the upstream repo.

(And isn't me forking your repo for the sake of creating this PR a violation of All Rights Reserved? 🤔 Anywayy)